### PR TITLE
[Ostro OS XT] Fallback to use MADV_DONTNEED in madvise

### DIFF
--- a/recipes-crosswalk/crosswalk/crosswalk/Ostro-OS-XT-Fallback-MADV_FREE-to-MADV_DONTNEED.patch
+++ b/recipes-crosswalk/crosswalk/crosswalk/Ostro-OS-XT-Fallback-MADV_FREE-to-MADV_DONTNEED.patch
@@ -1,0 +1,33 @@
+From 23ac8641cf1e51cb3b252db03ba89ec3a5d80063 Mon Sep 17 00:00:00 2001
+From: Ningxin Hu <ningxin@intel.com>
+Date: Fri, 9 Sep 2016 13:18:05 +0000
+Subject: [PATCH] [Ostro OS XT] Fallback MADV_FREE to MADV_DONTNEED
+
+MADV_FREE has wrong value on Ostro OS XT which causes madvise always
+returns -1. Fallback to MADV_DONTNEED.
+
+TODO=fix in Ostro OS XT upstream.
+---
+ third_party/WebKit/Source/wtf/PageAllocator.cpp | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/third_party/WebKit/Source/wtf/PageAllocator.cpp b/third_party/WebKit/Source/wtf/PageAllocator.cpp
+index 7f7a884..15377b0 100644
+--- a/third_party/WebKit/Source/wtf/PageAllocator.cpp
++++ b/third_party/WebKit/Source/wtf/PageAllocator.cpp
+@@ -42,6 +42,12 @@
+ 
+ #ifndef MADV_FREE
+ #define MADV_FREE MADV_DONTNEED
++#else
++// [Ostro OS XT] MADV_FREE has wrong value which causes madvise
++// always returns -1. Fallback to MADV_DONTNEED.
++// TODO: fix in Ostro OS XT upstream.
++#undef MADV_FREE
++#define MADV_FREE MADV_DONTNEED
+ #endif
+ 
+ #ifndef MAP_ANONYMOUS
+-- 
+2.8.4
+

--- a/recipes-crosswalk/crosswalk/crosswalk_20.50.533.12.bb
+++ b/recipes-crosswalk/crosswalk/crosswalk_20.50.533.12.bb
@@ -359,6 +359,7 @@ SRC_URI += "\
     https://download.01.org/crosswalk/releases/crosswalk/source/crosswalk-${PV}.tar.xz;name=tarball \
     file://use_window_manager_native_decorations.patch \
     file://pick_yocto_compiler.patch \
+    file://Ostro-OS-XT-Fallback-MADV_FREE-to-MADV_DONTNEED.patch \
     file://include.gypi \
     "
 


### PR DESCRIPTION
The root cause is when running on Ostro OS XT, the MADV_FREE
(defined in glibc 2.24) is passed to the syscall madvise(),
while the kernel (4.4) cannot understand the value. This
then triggers a RELEASE_ASSERT.

This patch fallbacks to use MADV_DONTNEED before the issue gets
fixed in Ostro OS XT.

BUG=XWALK-7302