### PR TITLE
[Ostro OS XT] Set CAP_MAC_OVERRIDE capability for renderer process

### DIFF
--- a/recipes-crosswalk/crosswalk/crosswalk/Ostro-OS-XT-Set-CAP_MAC_OVERRIDE-capability-for-rend.patch
+++ b/recipes-crosswalk/crosswalk/crosswalk/Ostro-OS-XT-Set-CAP_MAC_OVERRIDE-capability-for-rend.patch
@@ -1,0 +1,92 @@
+From 57ea029326d3c036db7cc1b0fb8c9559100a3adc Mon Sep 17 00:00:00 2001
+From: Ningxin Hu <ningxin@intel.com>
+Date: Fri, 9 Sep 2016 15:50:02 +0000
+Subject: [PATCH] [Ostro OS XT] Set CAP_MAC_OVERRIDE capability for renderer
+ process
+
+Otherwise, the renderer process would receive SIGKILL.
+
+BUG=XWALK-7306
+---
+ sandbox/linux/services/credentials.cc     | 14 +++++++++++++-
+ sandbox/linux/services/credentials.h      |  3 +++
+ sandbox/linux/system_headers/capability.h |  3 +++
+ 3 files changed, 19 insertions(+), 1 deletion(-)
+
+diff --git a/sandbox/linux/services/credentials.cc b/sandbox/linux/services/credentials.cc
+index 76038af..dee154f 100644
+--- a/sandbox/linux/services/credentials.cc
++++ b/sandbox/linux/services/credentials.cc
+@@ -145,6 +145,8 @@ int CapabilityToKernelValue(Credentials::Capability cap) {
+       return CAP_SYS_CHROOT;
+     case Credentials::Capability::SYS_ADMIN:
+       return CAP_SYS_ADMIN;
++    case Credentials::Capability::MAC_OVERRIDE:
++      return CAP_MAC_OVERRIDE;
+   }
+ 
+   LOG(FATAL) << "Invalid Capability: " << static_cast<int>(cap);
+@@ -175,6 +177,13 @@ bool Credentials::DropAllCapabilitiesOnCurrentThread() {
+ }
+ 
+ // static
++bool Credentials::DropAllCapabilitiesExceptMacOverrideOnCurrentThread() {
++  std::vector<Capability> caps;
++  caps.push_back(Capability::MAC_OVERRIDE);
++  return SetCapabilitiesOnCurrentThread(caps);
++}
++
++// static
+ bool Credentials::SetCapabilitiesOnCurrentThread(
+     const std::vector<Capability>& caps) {
+   struct cap_hdr hdr = {};
+@@ -329,7 +338,10 @@ pid_t Credentials::ForkAndDropCapabilitiesInChild() {
+   }
+ 
+   // Since we just forked, we are single threaded.
+-  PCHECK(DropAllCapabilitiesOnCurrentThread());
++  // [Ostro OS XT]: Child process receives SIGKILL if the
++  // CAP_MAC_OVERRIDE capability is not set.
++  PCHECK(DropAllCapabilitiesExceptMacOverrideOnCurrentThread());
++
+   return 0;
+ }
+ 
+diff --git a/sandbox/linux/services/credentials.h b/sandbox/linux/services/credentials.h
+index 095d636..347e4f2 100644
+--- a/sandbox/linux/services/credentials.h
++++ b/sandbox/linux/services/credentials.h
+@@ -32,6 +32,7 @@ class SANDBOX_EXPORT Credentials {
+   enum class Capability {
+     SYS_CHROOT,
+     SYS_ADMIN,
++    MAC_OVERRIDE,
+   };
+ 
+   // Drop all capabilities in the effective, inheritable and permitted sets for
+@@ -54,6 +55,8 @@ class SANDBOX_EXPORT Credentials {
+   // threads will not be changed. This is dangerous, do not use unless you nkow
+   // what you are doing.
+   static bool DropAllCapabilitiesOnCurrentThread() WARN_UNUSED_RESULT;
++  static bool DropAllCapabilitiesExceptMacOverrideOnCurrentThread()
++      WARN_UNUSED_RESULT;
+   static bool SetCapabilitiesOnCurrentThread(
+       const std::vector<Capability>& caps) WARN_UNUSED_RESULT;
+ 
+diff --git a/sandbox/linux/system_headers/capability.h b/sandbox/linux/system_headers/capability.h
+index f91fcf7..ebc5f5b 100644
+--- a/sandbox/linux/system_headers/capability.h
++++ b/sandbox/linux/system_headers/capability.h
+@@ -27,6 +27,9 @@
+ #ifndef CAP_SYS_ADMIN
+ #define CAP_SYS_ADMIN 21
+ #endif
++#ifndef CAP_MAC_OVERRIDE
++#define CAP_MAC_OVERRIDE 32
++#endif
+ 
+ struct cap_hdr {
+   uint32_t version;
+-- 
+2.8.4
+

--- a/recipes-crosswalk/crosswalk/crosswalk_20.50.533.12.bb
+++ b/recipes-crosswalk/crosswalk/crosswalk_20.50.533.12.bb
@@ -360,6 +360,7 @@ SRC_URI += "\
     file://use_window_manager_native_decorations.patch \
     file://pick_yocto_compiler.patch \
     file://Ostro-OS-XT-Fallback-MADV_FREE-to-MADV_DONTNEED.patch \
+    file://Ostro-OS-XT-Set-CAP_MAC_OVERRIDE-capability-for-rend.patch \
     file://include.gypi \
     "
 


### PR DESCRIPTION
Otherwise, the renderer process would receive SIGKILL.

BUG=XWALK-7306